### PR TITLE
Bump firebase-core dependency to firebase-analytics.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,5 +29,5 @@ dependencies {
     testImplementation files('libs/java-json.jar')
     testImplementation files('libs/test-utils.aar')
 
-    implementation 'com.google.firebase:firebase-core:16.0.6'
+    implementation 'com.google.firebase:firebase-core:17.2.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,5 +29,5 @@ dependencies {
     testImplementation files('libs/java-json.jar')
     testImplementation files('libs/test-utils.aar')
 
-    implementation 'com.google.firebase:firebase-analytics:17.3.0'
+    compileOnly 'com.google.firebase:firebase-analytics:17.3.0'
 }


### PR DESCRIPTION
firebase-core is no longer needed. See new guidance here: https://firebase.google.com/docs/android/setup?authuser=0#available-libraries