### PR TITLE
Fix crash on startup

### DIFF
--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
@@ -49,11 +49,7 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
 
     @Override
     protected List<ReportingMessage> onKitCreate(Map<String, String> map, Context context) throws IllegalArgumentException {
-        try {
-            FirebaseAnalytics.getInstance(context).getFirebaseInstanceId();
-        } catch (Exception ex) {
-            throw new RuntimeException("Firebase not initialized. Check to make sure your google-services.json file is in the correct location");
-        }
+        Logger.info(getName() + " Kit relies on a functioning instance of Firebase Analytics. If your Firebase Analytics instance is not configured properly, this Kit will not work");
         return null;
     }
 


### PR DESCRIPTION
We are calling a method in onKitCreate() that will crash if run on the main thread. The purpose of the method we are calling is solely to check that Firebase is configured properly and can run. There aren't really any side effects other than the kit now starting and eating events if Firebase isn't working, rather than shutting down