### PR TITLE
Fix Screen name length when forwarding to GA firebase

### DIFF
--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
@@ -85,7 +85,7 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
     public List<ReportingMessage> logScreen(String s, Map<String, String> map) {
         Activity activity = getCurrentActivity().get();
         if (activity != null) {
-            FirebaseAnalytics.getInstance(getContext()).setCurrentScreen(activity, standardizeName(s, false), null);
+            FirebaseAnalytics.getInstance(getContext()).setCurrentScreen(activity, standardizeName(s, true), null);
             return Collections.singletonList(new ReportingMessage(this, ReportingMessage.MessageType.SCREEN_VIEW, System.currentTimeMillis(), null));
         }
         return null;


### PR DESCRIPTION
Currently when standardizing screen names we pass false here(https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase/blob/e455767b72a72d90a820651836dc2da883225c98/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java#L88) which causes us to truncate the name to 24 characters instead of 40 cause it fails this if condition(https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase/blob/e455767b72a72d90a820651836dc2da883225c98/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java#L363)

 