### PR TITLE
fix: Add missing unit test stub

### DIFF
--- a/src/test/java/android/os/Bundle.java
+++ b/src/test/java/android/os/Bundle.java
@@ -22,6 +22,10 @@ public class Bundle {
         map.put(key, value);
     }
 
+    public void putLong(String key, long value) { map.put(key, value); }
+
+    public void putInt(String key, int value) { map.put(key, value); }
+
     public void putParcelableArray(String key, Parcelable[] value) {
         map.put(key, value);
     }


### PR DESCRIPTION
Add missing mock methods for Bundler to resolve MethodNotFound exception during unit test execution