### PR TITLE
feat: Add shipping and payment event types

### DIFF
--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
@@ -35,6 +35,10 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
     final static String USER_ID_EMAIL_VALUE = "email";
     final static String USER_ID_MPID_VALUE = "mpid";
 
+    final static String CF_GA4COMMERCE_EVENT_TYPE = "GA4.CommerceEventType";
+    final static String CF_GA4_PAYMENT_TYPE = "GA4.PaymentType";
+    final static String CF_GA4_SHIPPING_TIER = "GA4.ShippingTier";
+
     private static String[] forbiddenPrefixes = new String[]{"google_", "firebase_", "ga_"};
     private static int eventMaxLength = 40;
     private static int userAttributeMaxLength = 24;
@@ -128,7 +132,23 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
                 eventName = FirebaseAnalytics.Event.SELECT_CONTENT;
                 break;
             case Product.CHECKOUT_OPTION:
-                eventName = FirebaseAnalytics.Event.SET_CHECKOUT_OPTION;
+                Map<String, List<String>> customFlags = commerceEvent.getCustomFlags();
+                if (customFlags != null && customFlags.containsKey(CF_GA4COMMERCE_EVENT_TYPE)) {
+                    String commerceEventType = customFlags.get(CF_GA4COMMERCE_EVENT_TYPE).get(0);
+                    if (commerceEventType == FirebaseAnalytics.Event.ADD_SHIPPING_INFO) {
+                        eventName = FirebaseAnalytics.Event.ADD_SHIPPING_INFO;
+                    } else if (commerceEventType == FirebaseAnalytics.Event.ADD_PAYMENT_INFO) {
+                        eventName = FirebaseAnalytics.Event.ADD_PAYMENT_INFO;
+                    } else {
+                        // TODO: SET_CHECKOUT_OPTION is deprecated, we should update our docs for Firebase.
+                        Logger.warning("You used an unsupported value for the custom flag 'GA4.CommerceEventType'. Please check your code. The event will be sent to Firebase with the deprecated SET_CHECKOUT_OPTION event type");
+                        eventName = FirebaseAnalytics.Event.SET_CHECKOUT_OPTION;
+                    }
+                } else {
+                    Logger.warning("Setting a CHECKOUT_OPTION now requires a custom flag of 'GA4.CommerceEventType'. Please review the mParticle documentation.");
+                    eventName = FirebaseAnalytics.Event.SET_CHECKOUT_OPTION;
+                }
+
                 break;
             case Product.DETAIL:
                 eventName = FirebaseAnalytics.Event.VIEW_ITEM;
@@ -209,6 +229,24 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
             Logger.info("Currency field required by Firebase was not set, defaulting to 'USD'");
             currency = "USD";
         }
+
+        // Google Analytics 4 introduces 2 new event types - add_shipping_info and add_payment_info
+        // each of these has an extra parameter that is optional to be included
+        Map<String, List<String>> customFlags = commerceEvent.getCustomFlags();
+        if (customFlags != null && customFlags.containsKey(CF_GA4COMMERCE_EVENT_TYPE)) {
+            // TODO: Will get 0 throw if the array is empty?
+            String commerceEventType = customFlags.get(CF_GA4COMMERCE_EVENT_TYPE).get(0);
+            if (commerceEventType == FirebaseAnalytics.Event.ADD_SHIPPING_INFO) {
+                if (customFlags.containsKey(CF_GA4_SHIPPING_TIER)) {
+                    // TODO: if the shipping tier is null/nil, what happens?
+                    pickyBundle.putString(FirebaseAnalytics.Param.SHIPPING_TIER, customFlags.get(CF_GA4_SHIPPING_TIER).get(0));
+                }
+            } else if (commerceEventType == FirebaseAnalytics.Event.ADD_PAYMENT_INFO) {
+                if (customFlags.containsKey(CF_GA4_PAYMENT_TYPE)) {
+                    pickyBundle.putString(FirebaseAnalytics.Param.PAYMENT_TYPE, customFlags.get(CF_GA4_PAYMENT_TYPE).get(0));
+                }
+            }
+        }
         return pickyBundle
                 .putString(FirebaseAnalytics.Param.CURRENCY, currency)
                 .putBundleList(FirebaseAnalytics.Param.ITEMS, getProductBundles(commerceEvent))
@@ -235,6 +273,8 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
     PickyBundle getTransactionAttributesBundle(CommerceEvent commerceEvent) {
         PickyBundle pickyBundle = new PickyBundle();
         TransactionAttributes transactionAttributes = commerceEvent.getTransactionAttributes();
+
+//        if
         if (commerceEvent.getTransactionAttributes() == null) {
             return pickyBundle;
         }

--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
@@ -135,9 +135,9 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
                 Map<String, List<String>> customFlags = commerceEvent.getCustomFlags();
                 if (customFlags != null && customFlags.containsKey(CF_GA4COMMERCE_EVENT_TYPE)) {
                     String commerceEventType = customFlags.get(CF_GA4COMMERCE_EVENT_TYPE).get(0);
-                    if (commerceEventType == FirebaseAnalytics.Event.ADD_SHIPPING_INFO) {
+                    if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_SHIPPING_INFO.toString())) {
                         eventName = FirebaseAnalytics.Event.ADD_SHIPPING_INFO;
-                    } else if (commerceEventType == FirebaseAnalytics.Event.ADD_PAYMENT_INFO) {
+                    } else if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_PAYMENT_INFO.toString())) {
                         eventName = FirebaseAnalytics.Event.ADD_PAYMENT_INFO;
                     } else {
                         // TODO: SET_CHECKOUT_OPTION is deprecated, we should update our docs for Firebase.
@@ -231,17 +231,17 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
         }
 
         // Google Analytics 4 introduces 2 new event types - add_shipping_info and add_payment_info
-        // each of these has an extra parameter that is optional to be included
+        // each of these has an extra parameter that is optional
         Map<String, List<String>> customFlags = commerceEvent.getCustomFlags();
         if (customFlags != null && customFlags.containsKey(CF_GA4COMMERCE_EVENT_TYPE)) {
             // TODO: Will get 0 throw if the array is empty?
             String commerceEventType = customFlags.get(CF_GA4COMMERCE_EVENT_TYPE).get(0);
-            if (commerceEventType == FirebaseAnalytics.Event.ADD_SHIPPING_INFO) {
+            if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_SHIPPING_INFO.toString())) {
                 if (customFlags.containsKey(CF_GA4_SHIPPING_TIER)) {
                     // TODO: if the shipping tier is null/nil, what happens?
                     pickyBundle.putString(FirebaseAnalytics.Param.SHIPPING_TIER, customFlags.get(CF_GA4_SHIPPING_TIER).get(0));
                 }
-            } else if (commerceEventType == FirebaseAnalytics.Event.ADD_PAYMENT_INFO) {
+            } else if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_PAYMENT_INFO.toString())) {
                 if (customFlags.containsKey(CF_GA4_PAYMENT_TYPE)) {
                     pickyBundle.putString(FirebaseAnalytics.Param.PAYMENT_TYPE, customFlags.get(CF_GA4_PAYMENT_TYPE).get(0));
                 }
@@ -274,7 +274,6 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
         PickyBundle pickyBundle = new PickyBundle();
         TransactionAttributes transactionAttributes = commerceEvent.getTransactionAttributes();
 
-//        if
         if (commerceEvent.getTransactionAttributes() == null) {
             return pickyBundle;
         }

--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
@@ -233,17 +233,21 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
         // each of these has an extra parameter that is optional
         Map<String, List<String>> customFlags = commerceEvent.getCustomFlags();
         if (customFlags != null && customFlags.containsKey(CF_GA4COMMERCE_EVENT_TYPE)) {
-            // TODO: Will get 0 throw an error if the array is empty?
-            String commerceEventType = customFlags.get(CF_GA4COMMERCE_EVENT_TYPE).get(0);
-            if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_SHIPPING_INFO.toString())) {
-                if (customFlags.containsKey(CF_GA4_SHIPPING_TIER)) {
-                    pickyBundle.putString(FirebaseAnalytics.Param.SHIPPING_TIER, customFlags.get(CF_GA4_SHIPPING_TIER).get(0));
+            List<String> commerceEventTypeList = customFlags.get(CF_GA4COMMERCE_EVENT_TYPE);
+                if (commerceEventTypeList != null && commerceEventTypeList.size() > 0) {
+                    String commerceEventType = commerceEventTypeList.get(0);
+                    if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_SHIPPING_INFO.toString())) {
+                        List<String> shippingTier = customFlags.get(CF_GA4_SHIPPING_TIER);
+                        if (shippingTier !=null && shippingTier.size() > 0) {
+                            pickyBundle.putString(FirebaseAnalytics.Param.SHIPPING_TIER, shippingTier.get(0));
+                        }
+                    } else if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_PAYMENT_INFO.toString())) {
+                        List<String> paymentType = customFlags.get(CF_GA4_PAYMENT_TYPE);
+                        if (paymentType !=null && paymentType.size() > 0) {
+                            pickyBundle.putString(FirebaseAnalytics.Param.PAYMENT_TYPE, paymentType.get(0));
+                        }
+                    }
                 }
-            } else if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_PAYMENT_INFO.toString())) {
-                if (customFlags.containsKey(CF_GA4_PAYMENT_TYPE)) {
-                    pickyBundle.putString(FirebaseAnalytics.Param.PAYMENT_TYPE, customFlags.get(CF_GA4_PAYMENT_TYPE).get(0));
-                }
-            }
         }
         return pickyBundle
                 .putString(FirebaseAnalytics.Param.CURRENCY, currency)

--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
@@ -140,7 +140,6 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
                     } else if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_PAYMENT_INFO.toString())) {
                         eventName = FirebaseAnalytics.Event.ADD_PAYMENT_INFO;
                     } else {
-                        // TODO: SET_CHECKOUT_OPTION is deprecated, we should update our docs for Firebase.
                         Logger.warning("You used an unsupported value for the custom flag 'GA4.CommerceEventType'. Please check your code. The event will be sent to Firebase with the deprecated SET_CHECKOUT_OPTION event type");
                         eventName = FirebaseAnalytics.Event.SET_CHECKOUT_OPTION;
                     }
@@ -198,7 +197,7 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
         if (!KitUtils.isEmpty(userId)) {
             FirebaseAnalytics.getInstance(getContext()).setUserId(userId);
         }
-        }
+    }
 
     String getFirebaseEventName(MPEvent event) {
         switch (event.getEventType()) {
@@ -234,11 +233,10 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
         // each of these has an extra parameter that is optional
         Map<String, List<String>> customFlags = commerceEvent.getCustomFlags();
         if (customFlags != null && customFlags.containsKey(CF_GA4COMMERCE_EVENT_TYPE)) {
-            // TODO: Will get 0 throw if the array is empty?
+            // TODO: Will get 0 throw an error if the array is empty?
             String commerceEventType = customFlags.get(CF_GA4COMMERCE_EVENT_TYPE).get(0);
             if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_SHIPPING_INFO.toString())) {
                 if (customFlags.containsKey(CF_GA4_SHIPPING_TIER)) {
-                    // TODO: if the shipping tier is null/nil, what happens?
                     pickyBundle.putString(FirebaseAnalytics.Param.SHIPPING_TIER, customFlags.get(CF_GA4_SHIPPING_TIER).get(0));
                 }
             } else if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_PAYMENT_INFO.toString())) {

--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
@@ -234,20 +234,20 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
         Map<String, List<String>> customFlags = commerceEvent.getCustomFlags();
         if (customFlags != null && customFlags.containsKey(CF_GA4COMMERCE_EVENT_TYPE)) {
             List<String> commerceEventTypeList = customFlags.get(CF_GA4COMMERCE_EVENT_TYPE);
-                if (commerceEventTypeList != null && commerceEventTypeList.size() > 0) {
-                    String commerceEventType = commerceEventTypeList.get(0);
-                    if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_SHIPPING_INFO.toString())) {
-                        List<String> shippingTier = customFlags.get(CF_GA4_SHIPPING_TIER);
-                        if (shippingTier !=null && shippingTier.size() > 0) {
-                            pickyBundle.putString(FirebaseAnalytics.Param.SHIPPING_TIER, shippingTier.get(0));
-                        }
-                    } else if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_PAYMENT_INFO.toString())) {
-                        List<String> paymentType = customFlags.get(CF_GA4_PAYMENT_TYPE);
-                        if (paymentType !=null && paymentType.size() > 0) {
-                            pickyBundle.putString(FirebaseAnalytics.Param.PAYMENT_TYPE, paymentType.get(0));
-                        }
+            if (commerceEventTypeList != null && commerceEventTypeList.size() > 0) {
+                String commerceEventType = commerceEventTypeList.get(0);
+                if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_SHIPPING_INFO.toString())) {
+                    List<String> shippingTier = customFlags.get(CF_GA4_SHIPPING_TIER);
+                    if (shippingTier != null && shippingTier.size() > 0) {
+                        pickyBundle.putString(FirebaseAnalytics.Param.SHIPPING_TIER, shippingTier.get(0));
+                    }
+                } else if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_PAYMENT_INFO.toString())) {
+                    List<String> paymentType = customFlags.get(CF_GA4_PAYMENT_TYPE);
+                    if (paymentType != null && paymentType.size() > 0) {
+                        pickyBundle.putString(FirebaseAnalytics.Param.PAYMENT_TYPE, paymentType.get(0));
                     }
                 }
+            }
         }
         return pickyBundle
                 .putString(FirebaseAnalytics.Param.CURRENCY, currency)

--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
@@ -134,17 +134,23 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
             case Product.CHECKOUT_OPTION:
                 Map<String, List<String>> customFlags = commerceEvent.getCustomFlags();
                 if (customFlags != null && customFlags.containsKey(CF_GA4COMMERCE_EVENT_TYPE)) {
-                    String commerceEventType = customFlags.get(CF_GA4COMMERCE_EVENT_TYPE).get(0);
-                    if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_SHIPPING_INFO.toString())) {
-                        eventName = FirebaseAnalytics.Event.ADD_SHIPPING_INFO;
-                    } else if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_PAYMENT_INFO.toString())) {
-                        eventName = FirebaseAnalytics.Event.ADD_PAYMENT_INFO;
+                    List<String> commerceEventTypes = customFlags.get(CF_GA4COMMERCE_EVENT_TYPE);
+                    if (!commerceEventTypes.isEmpty()) {
+                        String commerceEventType = commerceEventTypes.get(0);
+                        if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_SHIPPING_INFO.toString())) {
+                            eventName = FirebaseAnalytics.Event.ADD_SHIPPING_INFO;
+                        } else if (commerceEventType.equals(FirebaseAnalytics.Event.ADD_PAYMENT_INFO.toString())) {
+                            eventName = FirebaseAnalytics.Event.ADD_PAYMENT_INFO;
+                        } else {
+                            Logger.warning("You used an unsupported value for the custom flag 'GA4.CommerceEventType'. Please review the mParticle documentation. The event will be sent to Firebase with the deprecated SET_CHECKOUT_OPTION event type.");
+                            eventName = FirebaseAnalytics.Event.SET_CHECKOUT_OPTION;
+                        }
                     } else {
-                        Logger.warning("You used an unsupported value for the custom flag 'GA4.CommerceEventType'. Please check your code. The event will be sent to Firebase with the deprecated SET_CHECKOUT_OPTION event type");
+                        Logger.warning("Setting a CHECKOUT_OPTION now requires a custom flag of 'GA4.CommerceEventType'. Please review the mParticle documentation.  The event will be sent to Firebase with the deprecated SET_CHECKOUT_OPTION event type.");
                         eventName = FirebaseAnalytics.Event.SET_CHECKOUT_OPTION;
                     }
                 } else {
-                    Logger.warning("Setting a CHECKOUT_OPTION now requires a custom flag of 'GA4.CommerceEventType'. Please review the mParticle documentation.");
+                    Logger.warning("Setting a CHECKOUT_OPTION now requires a custom flag of 'GA4.CommerceEventType'. Please review the mParticle documentation.  The event will be sent to Firebase with the deprecated SET_CHECKOUT_OPTION event type.");
                     eventName = FirebaseAnalytics.Event.SET_CHECKOUT_OPTION;
                 }
 

--- a/src/test/java/com/google/firebase/analytics/FirebaseAnalytics.java
+++ b/src/test/java/com/google/firebase/analytics/FirebaseAnalytics.java
@@ -21,6 +21,11 @@ public class FirebaseAnalytics {
     static String firebaseId;
     private String currentScreen;
 
+    public static class Event {
+        public static final String ADD_PAYMENT_INFO = "add_payment_info";
+        public static final String ADD_SHIPPING_INFO = "add_shipping_info";
+    }
+
 
     static FirebaseAnalytics instance;
 

--- a/src/test/java/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.java
+++ b/src/test/java/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.logging.Logger;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
@@ -44,6 +45,8 @@ public class GoogleAnalyticsFirebaseKitTest {
     GoogleAnalyticsFirebaseKit kitInstance;
     FirebaseAnalytics firebaseSdk;
     Random random = new Random();
+    private static Logger LOGGER = Logger.getLogger("InfoLogging");
+
 
     @Before
     public void before() throws JSONException {
@@ -109,6 +112,42 @@ public class GoogleAnalyticsFirebaseKitTest {
         CommerceEvent event = new CommerceEvent.Builder(Promotion.CLICK, promotion).build();
         kitInstance.logEvent(event);
         assertEquals(0, firebaseSdk.getLoggedEvents().size());
+    }
+
+    @Test
+    public void testShippingInfoCommerceEvent() {
+        CommerceEvent event = new CommerceEvent.Builder(Product.CHECKOUT_OPTION, new Product.Builder("asdv", "asdv", 1.3).build())
+                .addCustomFlag("GA4.CommerceEventType", "add_shipping_info")
+                .addCustomFlag("GA4.ShippingTier", "overnight")
+                .build();
+        kitInstance.logEvent(event);
+
+        assertEquals(1, firebaseSdk.getLoggedEvents().size());
+        assertEquals("add_shipping_info", firebaseSdk.getLoggedEvents().get(0).getKey());
+        assertEquals("overnight", firebaseSdk.getLoggedEvents().get(0).getValue().getString("shipping_tier"));
+    }
+
+    @Test
+    public void testPaymentInfoCommerceEvent() {
+        CommerceEvent event = new CommerceEvent.Builder(Product.CHECKOUT_OPTION, new Product.Builder("asdv", "asdv", 1.3).build())
+                .addCustomFlag("GA4.CommerceEventType", "add_payment_info")
+                .addCustomFlag("GA4.PaymentType", "visa")
+                .build();
+        kitInstance.logEvent(event);
+
+        assertEquals(1, firebaseSdk.getLoggedEvents().size());
+        assertEquals("add_payment_info", firebaseSdk.getLoggedEvents().get(0).getKey());
+        assertEquals("visa", firebaseSdk.getLoggedEvents().get(0).getValue().getString("payment_type"));
+    }
+
+    @Test
+    public void testCheckoutOptionCommerceEvent() {
+        CommerceEvent event = new CommerceEvent.Builder(Product.CHECKOUT_OPTION, new Product.Builder("asdv", "asdv", 1.3).build())
+                .build();
+        kitInstance.logEvent(event);
+
+        assertEquals(1, firebaseSdk.getLoggedEvents().size());
+        assertEquals("set_checkout_option", firebaseSdk.getLoggedEvents().get(0).getKey());
     }
 
     @Test

--- a/src/test/java/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.java
+++ b/src/test/java/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.java
@@ -45,8 +45,6 @@ public class GoogleAnalyticsFirebaseKitTest {
     GoogleAnalyticsFirebaseKit kitInstance;
     FirebaseAnalytics firebaseSdk;
     Random random = new Random();
-    private static Logger LOGGER = Logger.getLogger("InfoLogging");
-
 
     @Before
     public void before() throws JSONException {

--- a/src/test/java/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.java
+++ b/src/test/java/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.java
@@ -117,7 +117,7 @@ public class GoogleAnalyticsFirebaseKitTest {
     @Test
     public void testShippingInfoCommerceEvent() {
         CommerceEvent event = new CommerceEvent.Builder(Product.CHECKOUT_OPTION, new Product.Builder("asdv", "asdv", 1.3).build())
-                .addCustomFlag("GA4.CommerceEventType", "add_shipping_info")
+                .addCustomFlag("GA4.CommerceEventType", FirebaseAnalytics.Event.ADD_SHIPPING_INFO)
                 .addCustomFlag("GA4.ShippingTier", "overnight")
                 .build();
         kitInstance.logEvent(event);
@@ -130,7 +130,7 @@ public class GoogleAnalyticsFirebaseKitTest {
     @Test
     public void testPaymentInfoCommerceEvent() {
         CommerceEvent event = new CommerceEvent.Builder(Product.CHECKOUT_OPTION, new Product.Builder("asdv", "asdv", 1.3).build())
-                .addCustomFlag("GA4.CommerceEventType", "add_payment_info")
+                .addCustomFlag("GA4.CommerceEventType", FirebaseAnalytics.Event.ADD_PAYMENT_INFO)
                 .addCustomFlag("GA4.PaymentType", "visa")
                 .build();
         kitInstance.logEvent(event);


### PR DESCRIPTION
# Summary

A new codepath is required because our API does not support `add_shipping_info`, nor `add_payment_info`, which GA4 now supports.

Firebase (and consequently, Google Analytics 4, which uses Firebases data model and is what prompted this PR), deprecated `set_checkout_option` in favor of `add_shipping_info` and `add_payment_info`.  These will be passed via a custom flag of `GA.CommerceEventType` on a `Checkout_Option` ProductActionType.

If the value of `GA.CommerceEventType` is `add_shipping_info`, a user can optionally add a `shipping_tier` custom flag.  If `add_payment_info` is chosen, a user can optionally add `payment_type` custom flag.