### PR TITLE
feat: set Firebase Analytics SDK version upper bound

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,6 @@ dependencies {
     testImplementation files('libs/test-utils.aar')
     testImplementation 'androidx.appcompat:appcompat:1.4.1'
 
-    compileOnly 'com.google.firebase:firebase-analytics:[17.3.0,)'
+    compileOnly 'com.google.firebase:firebase-analytics:[17.3.0,21.0.0)'
 
 }

--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
@@ -370,7 +370,7 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
         return name;
     }
 
-    class PickyBundle {
+    static class PickyBundle {
         private Bundle bundle = new Bundle();
 
         PickyBundle putString(String key, String value) {


### PR DESCRIPTION
# Summary
Firebase removed fields we depend on in their latest 21.0.0 release. Since [GoogleAnalyticsFirebaseGA4](https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase-ga4) replaced this kit and we are no longer maintaining this repo, cap the version to < 21.0.0

fixed an inner class declaration that was generating lint warnings