### PR TITLE
fix: Change empty space to white space

### DIFF
--- a/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
+++ b/src/main/java/com/mparticle/kits/GoogleAnalyticsFirebaseKit.java
@@ -346,7 +346,7 @@ public class GoogleAnalyticsFirebaseKit extends KitIntegration implements KitInt
         if (name == null) {
             return null;
         }
-        name = name.replaceAll("[^a-zA-Z0-9_\\s]", "");
+        name = name.replaceAll("[^a-zA-Z0-9_\\s]", " ");
         name = name.replaceAll("[\\s]+", "_");
 
         for(String forbiddenPrefix: forbiddenPrefixes) {


### PR DESCRIPTION
Change empty space typo to white space in standardizeName method

## Summary
- iOS and Android has different standardization behavior for Firebase integrations. This is caused by a typo in the Android kit where disallowed characters are replaced by empty space, when they should be replaced by space. 

## Testing Plan
- {explain how this has been tested, and what additional testing should be done}

## Reference Issue
- Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-4981
