### PR TITLE
fix: standardizeName empty space typo

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseKit.kt
@@ -338,7 +338,7 @@ class GoogleAnalyticsFirebaseKit : KitIntegration(), KitIntegration.EventListene
 
     fun standardizeName(nameIn: String?, event: Boolean): String? {
         var name = nameIn ?: return null
-        name = name.replace("[^a-zA-Z0-9_\\s]".toRegex(), "")
+        name = name.replace("[^a-zA-Z0-9_\\s]".toRegex(), " ")
         name = name.replace("[\\s]+".toRegex(), "_")
         for (forbiddenPrefix in forbiddenPrefixes) {
             if (name.startsWith(forbiddenPrefix)) {


### PR DESCRIPTION
Change empty space typo to white space in standardizeName method

##Summary
 - iOS and Android has different standardization behavior for Firebase integrations. This is caused by a typo in the Android kit where disallowed characters are replaced by empty space, when they should be replaced by space.
 
## Testing Plan
{explain how this has been tested, and what additional testing should be done}

## Reference Issue
Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-4981