### PR TITLE
Refactor checkout option code due to deprecation of 'CHECKOUT_OPTION' event

### DIFF
--- a/src/test/kotlin/com/google/firebase/analytics/FirebaseAnalytics.kt
+++ b/src/test/kotlin/com/google/firebase/analytics/FirebaseAnalytics.kt
@@ -11,7 +11,10 @@ class FirebaseAnalytics {
     var currentScreenName: String? = null
     var consentStateMap:MutableMap<Any, Any> = mutableMapOf()
 
-
+    object Event {
+        const val ADD_PAYMENT_INFO = "add_payment_info"
+        const val ADD_SHIPPING_INFO = "add_shipping_info"
+    }
     fun logEvent(key: String, bundle: Bundle) {
         loggedEvents.add(SimpleEntry(key, bundle))
     }

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.kt
@@ -660,6 +660,72 @@ class GoogleAnalyticsFirebaseKitTest {
         Assert.assertEquals(emptyMap<String, String>(), result)
     }
 
+    @Test
+    fun testShippingInfoCommerceEvent() {
+        val event = CommerceEvent.Builder(
+            Product.CHECKOUT_OPTION,
+            Product.Builder("asdv", "asdv", 1.3).build()
+        )
+            .addCustomFlag(
+                GoogleAnalyticsFirebaseKit.CF_COMMERCE_EVENT_TYPE,
+                FirebaseAnalytics.Event.ADD_SHIPPING_INFO
+            )
+            .addCustomFlag(GoogleAnalyticsFirebaseKit.CF_SHIPPING_TIER, "overnight")
+            .build()
+        kitInstance.logEvent(event)
+        TestCase.assertEquals(1, firebaseSdk.loggedEvents.size)
+        TestCase.assertEquals("add_shipping_info", firebaseSdk.loggedEvents[0].key)
+        TestCase.assertEquals(
+            "overnight",
+            firebaseSdk.loggedEvents[0].value.getString("shipping_tier")
+        )
+    }
+
+    @Test
+    fun testPaymentInfoCommerceEvent() {
+        val commerceCustomAttributes = mapOf(
+            "event::country" to "US"
+        )
+        val event = CommerceEvent.Builder(
+            Product.CHECKOUT_OPTION,
+            Product.Builder("asdv", "asdv", 1.3).build()
+        )
+            .addCustomFlag(
+                GoogleAnalyticsFirebaseKit.CF_COMMERCE_EVENT_TYPE,
+                FirebaseAnalytics.Event.ADD_PAYMENT_INFO
+            )
+            .addCustomFlag(GoogleAnalyticsFirebaseKit.CF_PAYMENT_TYPE, "visa")
+            .build()
+        event.customAttributes = commerceCustomAttributes
+        kitInstance.logEvent(event)
+        TestCase.assertEquals(1, firebaseSdk.loggedEvents.size)
+        TestCase.assertEquals("add_payment_info", firebaseSdk.loggedEvents[0].key)
+        TestCase.assertEquals("visa", firebaseSdk.loggedEvents[0].value.getString("payment_type"))
+        TestCase.assertEquals("US", firebaseSdk.loggedEvents[0].value.getString("event::country"))
+    }
+
+    @Test
+    fun testCheckoutOptionCommerceEvent() {
+        val customEventTypes = arrayOf(
+            FirebaseAnalytics.Event.ADD_PAYMENT_INFO,
+            FirebaseAnalytics.Event.ADD_SHIPPING_INFO
+        )
+        for (customEventType in customEventTypes) {
+            val event = CommerceEvent.Builder(
+                Product.CHECKOUT_OPTION,
+                Product.Builder("asdv", "asdv", 1.3).build()
+            )
+                .addCustomFlag(
+                    GoogleAnalyticsFirebaseKit.CF_COMMERCE_EVENT_TYPE,
+                    customEventType
+                )
+                .build()
+            kitInstance.logEvent(event)
+            TestCase.assertEquals(1, firebaseSdk.loggedEvents.size)
+            TestCase.assertEquals(customEventType, firebaseSdk.loggedEvents[0].key)
+            firebaseSdk.clearLoggedEvents()
+        }
+    }
 
     @Test
     fun testNameStandardization() {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Updated checkout option code due to deprecation of 'CHECKOUT_OPTION' event in Firebase for Android.
 Logic is same as GA4 CHECKOUT_OPTION (https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase-ga4/pull/21 )

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Verified through compilation and execution of a local application, as well as running the unit test case to validate the functionality.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6322