### PR TITLE
feat: use logEvent instead of deprecated setCurrentScreen and forward…

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseKit.kt
@@ -57,11 +57,16 @@ class GoogleAnalyticsFirebaseKit : KitIntegration(), KitIntegration.EventListene
         return listOf(ReportingMessage.fromEvent(this, mpEvent))
     }
 
-    override fun logScreen(s: String, map: Map<String, String>?): List<ReportingMessage> {
+    override fun logScreen(
+        screenName: String,
+        screenAttributes: Map<String, String>?
+    ): List<ReportingMessage> {
+        val bundle = toBundle(screenAttributes)
+        bundle.putString(FirebaseAnalytics.Param.SCREEN_NAME, standardizeName(screenName, true))
         val activity = currentActivity.get()
         if (activity != null) {
             FirebaseAnalytics.getInstance(context)
-                .setCurrentScreen(activity, standardizeName(s, true), null)
+                .logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, bundle)
             return listOf(
                 ReportingMessage(
                     this,

--- a/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/GoogleAnalyticsFirebaseKitTest.kt
@@ -784,9 +784,33 @@ class GoogleAnalyticsFirebaseKitTest {
     @Test
     fun testScreenNameSanitized() {
         kitInstance.logScreen("Some long Screen name", emptyMap())
+        val firebaseScreenViewEvent = firebaseSdk.loggedEvents[0]
         TestCase.assertEquals(
             "Some_long_Screen_name",
-            FirebaseAnalytics.getInstance(null)?.currentScreenName
+            firebaseScreenViewEvent.value.getString("screen_name")
+        )
+    }
+
+    @Test
+    fun testScreenNameAttributes() {
+        val attributes = hashMapOf<String, String>()
+        attributes["testAttributeKey"] = "testAttributeValue"
+        kitInstance.logScreen("testScreenName", attributes)
+        val firebaseScreenViewEvent = firebaseSdk.loggedEvents[0]
+        // even though we are passing one attribute, it should contain two including the screen_name
+        TestCase.assertEquals(
+            2,
+            firebaseScreenViewEvent.value.size()
+        )
+        // make sure the even name is correct with Firebase's constant SCREEN_NAME value
+        TestCase.assertEquals(
+            "screen_view",
+            firebaseScreenViewEvent.key
+        )
+        // make sure that the Params include the screenName value
+        TestCase.assertEquals(
+            "testScreenName",
+            firebaseScreenViewEvent.value.getString("screen_name")
         )
     }
 


### PR DESCRIPTION
… screenView attributes

 ## Summary
 - same as [this](https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase-ga4/pull/91) PR that was push for Firebase-GA4 kit

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - Unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-6971
